### PR TITLE
FIX Use correct type for title input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     type: string
     required: true
   title:
-    type: boolean
+    type: string
     required: true
   description:
     type: string


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/51

Not technically part of the issue, though may as well tack this PR on since it's in the same space

Strangely the `type: boolean` doesn't seem to have had any affect and pull-requests have still been getting created e.g. https://github.com/silverstripe/silverstripe-mfa/pull/492, though we should still make it the correct type regardless. I don't think this should be considered an API change because the type was simply wrong before